### PR TITLE
Use server time to get duration since last transaction

### DIFF
--- a/internal/payments/service.go
+++ b/internal/payments/service.go
@@ -59,7 +59,7 @@ func (s *paymentsService) CreatePayment(ctx context.Context, cashPaid, chickenPr
 			mostRecentPayment.CreatedAt.Minute(),
 			mostRecentPayment.CreatedAt.Second(),
 			mostRecentPayment.CreatedAt.Nanosecond(),
-			time.FixedZone("EAT", 3*60*60),
+			time.Local,
 		)
 		durationSinceLastPayment := currentTime.Sub(correctedMostRecentPaymentTime)
 

--- a/internal/purchases/service.go
+++ b/internal/purchases/service.go
@@ -53,7 +53,7 @@ func (s *purchaseService) CreatePurchase(ctx context.Context, chickenNo, chicken
 			mostRecentPurchase.CreatedAt.Minute(),
 			mostRecentPurchase.CreatedAt.Second(),
 			mostRecentPurchase.CreatedAt.Nanosecond(),
-			time.FixedZone("EAT", 3*60*60),
+			time.Local,
 		)
 		durationSinceLastPurchase := currentTime.Sub(correctedMostRecentPurchaseTime)
 


### PR DESCRIPTION
- Fixes bug in checking for duration since last transaction.
- Previous implementation used EAT fixed zone which caused a problem in the servers located elsewhere